### PR TITLE
Fix go-lint action

### DIFF
--- a/go-lint/Dockerfile
+++ b/go-lint/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine
+FROM golang:1.13
 
 LABEL "repository"="https://github.com/moorara/actions"
 LABEL "homepage"="https://github.com/moorara/actions/tree/master/go-lint"


### PR DESCRIPTION

  - [x] `go-lint`: switch to `golang:1.13` Docker image