### PR TITLE
Add missing path to go-lint args

### DIFF
--- a/go-lint/action.yml
+++ b/go-lint/action.yml
@@ -21,6 +21,7 @@ runs:
     - run
     - --new=${{ inputs.new }}
     - --deadline=${{ inputs.deadline }}
+    - ${{ inputs.path }}
 branding:
   icon: check
   color: purple


### PR DESCRIPTION
For `go-lint` action, `path` input was missing in args passed to Docker container.