### PR TITLE
Fix go-lint action path

### DIFF
--- a/go-cover/Dockerfile
+++ b/go-cover/Dockerfile
@@ -10,4 +10,3 @@ RUN wget -q -O /usr/local/bin/test-reporter https://codeclimate.com/downloads/te
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]
-CMD [ "./..." ]

--- a/go-lint/Dockerfile
+++ b/go-lint/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13
+FROM golang:1.13-alpine
 
 LABEL "repository"="https://github.com/moorara/actions"
 LABEL "homepage"="https://github.com/moorara/actions/tree/master/go-lint"
@@ -7,5 +7,5 @@ LABEL "maintainer"="Milad Irannejad <>"
 # Install golangci-lint (https://github.com/golangci/golangci-lint)
 RUN wget -qO - https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s latest
 
-ENTRYPOINT [ "golangci-lint" ]
-CMD [ "run", "./..." ]
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/go-lint/action.yml
+++ b/go-lint/action.yml
@@ -5,7 +5,7 @@ inputs:
   path:
     description: The root path of the directory containing Go files.
     required: false
-    default: ./...
+    default: .
   new:
     description: Whether or not to run linters only for new changes (default true).
     required: false
@@ -17,11 +17,6 @@ inputs:
 runs:
   using: docker
   image: Dockerfile
-  args:
-    - run
-    - --new=${{ inputs.new }}
-    - --deadline=${{ inputs.deadline }}
-    - ${{ inputs.path }}
 branding:
   icon: check
   color: purple

--- a/go-lint/entrypoint.sh
+++ b/go-lint/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -eu  # -o pipefail
+
+
+# Changing working directory to input path
+cd "$INPUT_PATH"
+
+# Run linters
+golangci-lint run \
+  --new="$INPUT_NEW" \
+  --deadline="$INPUT_DEADLINE" \
+  ./...


### PR DESCRIPTION
## Description

  - [x] Fixing `path` option for `go-lint` action

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change
  - [ ] Tests are provided/updated for the new change
